### PR TITLE
lsコマンドを作る2（オプション`-a`を追加）

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -8,9 +8,32 @@ COLUMNS = 3
 
 def main
   entries = Dir.entries(Dir.pwd).sort
-  entries.reject! { |entry| entry.start_with?('.') }
+  entries.reject! { |entry| entry.start_with?('.') } unless parse_command_line_options[:a]
 
   display_output(entries)
+end
+
+# コマンドラインから指定されたオプションを解析し、取得する。
+#
+# @return [Hash] 解析されたオプションがキーと値のペアでハッシュとして返される。
+#                例えば、`-a` オプションが指定された場合、 `{ a: true }` が返される。
+#                オプションが指定されない場合、デフォルトで `{ a: false }` が返される。
+#                また、無効なオプションが指定された場合は、エラーメッセージを表示し、プログラムを終了する。
+def parse_command_line_options
+  options = { a: false }
+
+  opts = OptionParser.new
+  opts.on('-a', 'do not ignore entries starting with .') { options[:a] = true }
+
+  begin
+    opts.parse(ARGV)
+  rescue OptionParser::InvalidOption
+    puts '指定されたオプションは無効です。以下、有効なオプションです。'
+    puts '  -a   .から始まるエントリも表示できます。'
+    exit 1
+  end
+
+  options
 end
 
 # 列幅を整えたファイルエントリをマトリクスで表示する。

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,8 +7,9 @@ require 'optparse'
 COLUMNS = 3
 
 def main
+  options = parse_command_line_options
   entries = Dir.entries(Dir.pwd).sort
-  entries.reject! { |entry| entry.start_with?('.') } unless parse_command_line_options[:a]
+  entries.reject! { |entry| entry.start_with?('.') } unless options[:a]
 
   display_output(entries)
 end
@@ -18,7 +19,7 @@ end
 # @return [Hash] 解析されたオプションがキーと値のペアでハッシュとして返される。
 #                例えば、`-a` オプションが指定された場合、 `{ a: true }` が返される。
 #                オプションが指定されない場合、デフォルトで `{ a: false }` が返される。
-#                また、無効なオプションが指定された場合は、エラーメッセージを表示し、プログラムを終了する。
+#                また、無効なオプションが指定された場合は、エラーメッセージを表示し、`{ a: false }`が返される。
 def parse_command_line_options
   options = { a: false }
 
@@ -28,9 +29,8 @@ def parse_command_line_options
   begin
     opts.parse(ARGV)
   rescue OptionParser::InvalidOption
-    puts '指定されたオプションは無効です。以下、有効なオプションです。'
-    puts '  -a   .から始まるエントリも表示できます。'
-    exit 1
+    puts 'Invalid Option'
+    puts opts.help
   end
 
   options


### PR DESCRIPTION
コマンドラインから指定されたオプション(`-a`)を解析し、取得する機能を追加しました。
ご都合の良いときにご確認いただければ幸いです。